### PR TITLE
feat: Build kingdom and town API endpoints

### DIFF
--- a/dotnet10/KingmakerKingdomSheet.ApiService/Endpoints/KingdomEndpoints.cs
+++ b/dotnet10/KingmakerKingdomSheet.ApiService/Endpoints/KingdomEndpoints.cs
@@ -1,0 +1,106 @@
+using KingmakerKingdomSheet.ApiService.Auth;
+using KingmakerKingdomSheet.Application.Contracts;
+using KingmakerKingdomSheet.Shared.DTOs;
+using System.Security.Claims;
+
+namespace KingmakerKingdomSheet.ApiService.Endpoints;
+
+public static class KingdomEndpoints
+{
+    public static void MapKingdomEndpoints(this WebApplication app)
+    {
+        var group = app.MapGroup("/api/kingdoms");
+
+        group.MapGet("/", ListKingdoms);
+        group.MapGet("/{id:guid}", GetKingdom);
+        group.MapPost("/", CreateKingdom).RequireAuthorization();
+        group.MapPut("/{id:guid}", UpdateKingdom).RequireAuthorization();
+        group.MapDelete("/{id:guid}", ArchiveKingdom).RequireAuthorization();
+    }
+
+    private static async Task<IResult> ListKingdoms(
+        IKingdomCatalogService catalogService,
+        CancellationToken ct)
+    {
+        var kingdoms = await catalogService.ListAsync(ct);
+        return Results.Ok(kingdoms);
+    }
+
+    private static async Task<IResult> GetKingdom(
+        Guid id,
+        IKingdomCatalogService catalogService,
+        CancellationToken ct)
+    {
+        var kingdom = await catalogService.GetAsync(id, ct);
+        
+        if (kingdom is null)
+            return Results.NotFound(new { error = "Kingdom not found" });
+
+        return Results.Ok(kingdom);
+    }
+
+    private static async Task<IResult> CreateKingdom(
+        CreateKingdomDto dto,
+        HttpContext httpContext,
+        IKingdomManagementService managementService,
+        CancellationToken ct)
+    {
+        var userIdClaim = httpContext.User.FindFirst(ClaimTypes.NameIdentifier);
+        if (userIdClaim == null || !Guid.TryParse(userIdClaim.Value, out var userId))
+            return Results.Unauthorized();
+
+        if (string.IsNullOrWhiteSpace(dto.Name))
+            return Results.BadRequest(new { error = "Kingdom name is required" });
+
+        var kingdom = await managementService.CreateAsync(userId, dto, ct);
+        return Results.Created($"/api/kingdoms/{kingdom.Id}", kingdom);
+    }
+
+    private static async Task<IResult> UpdateKingdom(
+        Guid id,
+        UpdateKingdomDto dto,
+        HttpContext httpContext,
+        IKingdomManagementService managementService,
+        IKingdomAuthorizationService authService,
+        CancellationToken ct)
+    {
+        var userIdClaim = httpContext.User.FindFirst(ClaimTypes.NameIdentifier);
+        if (userIdClaim == null || !Guid.TryParse(userIdClaim.Value, out var userId))
+            return Results.Unauthorized();
+
+        if (!await authService.HasPermissionAsync(userId, id, "manage-kingdom", ct))
+            return Results.Forbid();
+
+        if (string.IsNullOrWhiteSpace(dto.Name))
+            return Results.BadRequest(new { error = "Kingdom name is required" });
+
+        var kingdom = await managementService.UpdateAsync(id, dto, ct);
+
+        if (kingdom is null)
+            return Results.NotFound(new { error = "Kingdom not found" });
+
+        return Results.Ok(kingdom);
+    }
+
+    private static async Task<IResult> ArchiveKingdom(
+        Guid id,
+        HttpContext httpContext,
+        IKingdomManagementService managementService,
+        IKingdomAuthorizationService authService,
+        CancellationToken ct)
+    {
+        var userIdClaim = httpContext.User.FindFirst(ClaimTypes.NameIdentifier);
+        if (userIdClaim == null || !Guid.TryParse(userIdClaim.Value, out var userId))
+            return Results.Unauthorized();
+
+        if (!await authService.HasPermissionAsync(userId, id, "manage-kingdom", ct))
+            return Results.Forbid();
+
+        var success = await managementService.ArchiveAsync(id, ct);
+
+        if (!success)
+            return Results.NotFound(new { error = "Kingdom not found" });
+
+        return Results.NoContent();
+    }
+}

--- a/dotnet10/KingmakerKingdomSheet.ApiService/Endpoints/SettlementEndpoints.cs
+++ b/dotnet10/KingmakerKingdomSheet.ApiService/Endpoints/SettlementEndpoints.cs
@@ -1,0 +1,115 @@
+using KingmakerKingdomSheet.ApiService.Auth;
+using KingmakerKingdomSheet.Application.Contracts;
+using KingmakerKingdomSheet.Shared.DTOs;
+using System.Security.Claims;
+
+namespace KingmakerKingdomSheet.ApiService.Endpoints;
+
+public static class SettlementEndpoints
+{
+    public static void MapSettlementEndpoints(this WebApplication app)
+    {
+        var group = app.MapGroup("/api/kingdoms/{kingdomId:guid}/settlements");
+
+        group.MapGet("/", ListSettlements);
+        group.MapGet("/{id:guid}", GetSettlement);
+        group.MapPost("/", CreateSettlement).RequireAuthorization();
+        group.MapPut("/{id:guid}", UpdateSettlement).RequireAuthorization();
+        group.MapDelete("/{id:guid}", DeleteSettlement).RequireAuthorization();
+    }
+
+    private static async Task<IResult> ListSettlements(
+        Guid kingdomId,
+        ISettlementService settlementService,
+        CancellationToken ct)
+    {
+        var settlements = await settlementService.ListByKingdomAsync(kingdomId, ct);
+        return Results.Ok(settlements);
+    }
+
+    private static async Task<IResult> GetSettlement(
+        Guid kingdomId,
+        Guid id,
+        ISettlementService settlementService,
+        CancellationToken ct)
+    {
+        var settlement = await settlementService.GetAsync(id, ct);
+
+        if (settlement is null)
+            return Results.NotFound(new { error = "Settlement not found" });
+
+        return Results.Ok(settlement);
+    }
+
+    private static async Task<IResult> CreateSettlement(
+        Guid kingdomId,
+        CreateSettlementDto dto,
+        HttpContext httpContext,
+        ISettlementService settlementService,
+        IKingdomAuthorizationService authService,
+        CancellationToken ct)
+    {
+        var userIdClaim = httpContext.User.FindFirst(ClaimTypes.NameIdentifier);
+        if (userIdClaim == null || !Guid.TryParse(userIdClaim.Value, out var userId))
+            return Results.Unauthorized();
+
+        if (!await authService.HasPermissionAsync(userId, kingdomId, "manage-settlements", ct))
+            return Results.Forbid();
+
+        if (string.IsNullOrWhiteSpace(dto.Name))
+            return Results.BadRequest(new { error = "Settlement name is required" });
+
+        var settlement = await settlementService.CreateAsync(kingdomId, dto, ct);
+        return Results.Created($"/api/kingdoms/{kingdomId}/settlements/{settlement.Id}", settlement);
+    }
+
+    private static async Task<IResult> UpdateSettlement(
+        Guid kingdomId,
+        Guid id,
+        UpdateSettlementDto dto,
+        HttpContext httpContext,
+        ISettlementService settlementService,
+        IKingdomAuthorizationService authService,
+        CancellationToken ct)
+    {
+        var userIdClaim = httpContext.User.FindFirst(ClaimTypes.NameIdentifier);
+        if (userIdClaim == null || !Guid.TryParse(userIdClaim.Value, out var userId))
+            return Results.Unauthorized();
+
+        if (!await authService.HasPermissionAsync(userId, kingdomId, "manage-settlements", ct))
+            return Results.Forbid();
+
+        if (string.IsNullOrWhiteSpace(dto.Name))
+            return Results.BadRequest(new { error = "Settlement name is required" });
+
+        var settlement = await settlementService.UpdateAsync(id, dto, ct);
+
+        if (settlement is null)
+            return Results.NotFound(new { error = "Settlement not found" });
+
+        return Results.Ok(settlement);
+    }
+
+    private static async Task<IResult> DeleteSettlement(
+        Guid kingdomId,
+        Guid id,
+        HttpContext httpContext,
+        ISettlementService settlementService,
+        IKingdomAuthorizationService authService,
+        CancellationToken ct)
+    {
+        var userIdClaim = httpContext.User.FindFirst(ClaimTypes.NameIdentifier);
+        if (userIdClaim == null || !Guid.TryParse(userIdClaim.Value, out var userId))
+            return Results.Unauthorized();
+
+        if (!await authService.HasPermissionAsync(userId, kingdomId, "manage-settlements", ct))
+            return Results.Forbid();
+
+        var success = await settlementService.DeleteAsync(id, ct);
+
+        if (!success)
+            return Results.NotFound(new { error = "Settlement not found" });
+
+        return Results.NoContent();
+    }
+}

--- a/dotnet10/KingmakerKingdomSheet.ApiService/KingmakerKingdomSheet.ApiService.csproj
+++ b/dotnet10/KingmakerKingdomSheet.ApiService/KingmakerKingdomSheet.ApiService.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="KingmakerKingdomSheet.Application.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\KingmakerKingdomSheet.ServiceDefaults\KingmakerKingdomSheet.ServiceDefaults.csproj" />
     <ProjectReference Include="..\KingmakerKingdomSheet.Shared\KingmakerKingdomSheet.Shared.csproj" />
     <ProjectReference Include="..\KingmakerKingdomSheet.Application\KingmakerKingdomSheet.Application.csproj" />

--- a/dotnet10/KingmakerKingdomSheet.ApiService/Program.cs
+++ b/dotnet10/KingmakerKingdomSheet.ApiService/Program.cs
@@ -1,5 +1,6 @@
 using KingmakerKingdomSheet.ApiService.Auth;
 using KingmakerKingdomSheet.ApiService.Data;
+using KingmakerKingdomSheet.ApiService.Endpoints;
 using KingmakerKingdomSheet.ApiService.Services;
 using KingmakerKingdomSheet.Application.Contracts;
 using KingmakerKingdomSheet.Shared.DTOs;
@@ -39,6 +40,8 @@ builder.Services.AddDbContext<KingmakerDbContext>((serviceProvider, options) =>
 });
 
 builder.Services.AddScoped<IKingdomCatalogService, SqliteKingdomCatalogService>();
+builder.Services.AddScoped<IKingdomManagementService, SqliteKingdomManagementService>();
+builder.Services.AddScoped<ISettlementService, SqliteSettlementService>();
 builder.Services.AddScoped<IAuthService, AuthService>();
 builder.Services.AddScoped<IKingdomAuthorizationService, KingdomAuthorizationService>();
 builder.Services.AddSingleton<SqliteDevelopmentDatabaseInitializer>();
@@ -82,9 +85,7 @@ await using (var scope = app.Services.CreateAsyncScope())
     await databaseInitializer.InitializeAsync();
 }
 
-string[] summaries = ["Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"];
-
-app.MapGet("/", () => "API service is running. Navigate to /database/status to verify the SQLite development database or /weatherforecast to see sample data.");
+app.MapGet("/", () => "API service is running. Navigate to /database/status to verify the SQLite development database.");
 
 app.MapGet("/database/status", async (KingmakerDbContext dbContext, CancellationToken cancellationToken) =>
 {
@@ -110,19 +111,8 @@ app.MapGet("/database/status", async (KingmakerDbContext dbContext, Cancellation
     });
 });
 
-app.MapGet("/weatherforecast", () =>
-{
-    var forecast = Enumerable.Range(1, 5).Select(index =>
-        new WeatherForecast
-        (
-            DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
-            Random.Shared.Next(-20, 55),
-            summaries[Random.Shared.Next(summaries.Length)]
-        ))
-        .ToArray();
-    return forecast;
-})
-.WithName("GetWeatherForecast");
+app.MapKingdomEndpoints();
+app.MapSettlementEndpoints();
 
 app.MapPost("/api/auth/register", async (RegisterRequestDto dto, IAuthService authService, HttpContext httpContext) =>
 {
@@ -202,8 +192,3 @@ app.MapGet("/api/auth/me", async (HttpContext httpContext, IAuthService authServ
 app.MapDefaultEndpoints();
 
 app.Run();
-
-record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
-{
-    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
-}

--- a/dotnet10/KingmakerKingdomSheet.ApiService/Services/SqliteKingdomManagementService.cs
+++ b/dotnet10/KingmakerKingdomSheet.ApiService/Services/SqliteKingdomManagementService.cs
@@ -1,0 +1,114 @@
+using System.Text.RegularExpressions;
+using KingmakerKingdomSheet.ApiService.Data;
+using KingmakerKingdomSheet.Application.Contracts;
+using KingmakerKingdomSheet.Shared.DTOs;
+using Microsoft.EntityFrameworkCore;
+
+namespace KingmakerKingdomSheet.ApiService.Services;
+
+internal sealed partial class SqliteKingdomManagementService(KingmakerDbContext dbContext, IKingdomCatalogService catalogService) : IKingdomManagementService
+{
+    private const short GameMasterRoleTypeId = 1;
+
+    public async Task<KingdomDetailsDto> CreateAsync(Guid createdByUserId, CreateKingdomDto dto, CancellationToken ct = default)
+    {
+        var slug = GenerateSlug(dto.Name);
+        var now = DateTime.UtcNow;
+
+        var kingdom = new Kingdom
+        {
+            KingdomId = Guid.NewGuid(),
+            Name = dto.Name,
+            Slug = slug,
+            Description = dto.Description,
+            CreatedByUserAccountId = createdByUserId,
+            IsArchived = false,
+            CreatedUtc = now,
+            ModifiedUtc = now
+        };
+
+        dbContext.Kingdoms.Add(kingdom);
+
+        var participant = new KingdomParticipant
+        {
+            KingdomParticipantId = Guid.NewGuid(),
+            KingdomId = kingdom.KingdomId,
+            UserAccountId = createdByUserId,
+            IsActive = true,
+            ReceivesRealtimeUpdates = true,
+            JoinedUtc = now,
+            ModifiedUtc = now
+        };
+
+        dbContext.KingdomParticipants.Add(participant);
+
+        var gameMasterRole = new KingdomParticipantRole
+        {
+            KingdomParticipantId = participant.KingdomParticipantId,
+            KingdomRoleTypeId = GameMasterRoleTypeId,
+            IsPrimaryRole = true,
+            AssignedUtc = now
+        };
+
+        dbContext.KingdomParticipantRoles.Add(gameMasterRole);
+
+        await dbContext.SaveChangesAsync(ct);
+
+        var result = await catalogService.GetAsync(kingdom.KingdomId, ct);
+        return result!;
+    }
+
+    public async Task<KingdomDetailsDto?> UpdateAsync(Guid kingdomId, UpdateKingdomDto dto, CancellationToken ct = default)
+    {
+        var kingdom = await dbContext.Kingdoms
+            .SingleOrDefaultAsync(k => k.KingdomId == kingdomId && !k.IsArchived, ct);
+
+        if (kingdom is null)
+            return null;
+
+        kingdom.Name = dto.Name;
+        kingdom.Description = dto.Description;
+        kingdom.Slug = GenerateSlug(dto.Name);
+        kingdom.ModifiedUtc = DateTime.UtcNow;
+
+        await dbContext.SaveChangesAsync(ct);
+
+        return await catalogService.GetAsync(kingdomId, ct);
+    }
+
+    public async Task<bool> ArchiveAsync(Guid kingdomId, CancellationToken ct = default)
+    {
+        var kingdom = await dbContext.Kingdoms
+            .SingleOrDefaultAsync(k => k.KingdomId == kingdomId && !k.IsArchived, ct);
+
+        if (kingdom is null)
+            return false;
+
+        kingdom.IsArchived = true;
+        kingdom.ModifiedUtc = DateTime.UtcNow;
+
+        await dbContext.SaveChangesAsync(ct);
+
+        return true;
+    }
+
+    private static string GenerateSlug(string name)
+    {
+        var slug = name.ToLowerInvariant();
+        slug = SlugWhitespaceRegex().Replace(slug, "-");
+        slug = SlugInvalidCharsRegex().Replace(slug, "");
+        slug = SlugMultipleHyphensRegex().Replace(slug, "-");
+        slug = slug.Trim('-');
+        
+        return string.IsNullOrWhiteSpace(slug) ? "kingdom" : slug;
+    }
+
+    [GeneratedRegex(@"\s+")]
+    private static partial Regex SlugWhitespaceRegex();
+
+    [GeneratedRegex(@"[^a-z0-9-]")]
+    private static partial Regex SlugInvalidCharsRegex();
+
+    [GeneratedRegex(@"-+")]
+    private static partial Regex SlugMultipleHyphensRegex();
+}

--- a/dotnet10/KingmakerKingdomSheet.ApiService/Services/SqliteSettlementService.cs
+++ b/dotnet10/KingmakerKingdomSheet.ApiService/Services/SqliteSettlementService.cs
@@ -1,0 +1,99 @@
+using KingmakerKingdomSheet.ApiService.Data;
+using KingmakerKingdomSheet.Application.Contracts;
+using KingmakerKingdomSheet.Shared.DTOs;
+using Microsoft.EntityFrameworkCore;
+
+namespace KingmakerKingdomSheet.ApiService.Services;
+
+internal sealed class SqliteSettlementService(KingmakerDbContext dbContext) : ISettlementService
+{
+    public async Task<IReadOnlyList<TownDto>> ListByKingdomAsync(Guid kingdomId, CancellationToken ct = default)
+    {
+        return await dbContext.Settlements
+            .AsNoTracking()
+            .Include(s => s.Hex)
+            .Where(s => s.KingdomId == kingdomId)
+            .OrderBy(s => s.Name)
+            .Select(s => new TownDto(
+                s.SettlementId,
+                s.Name,
+                s.Hex != null ? s.Hex.CoordinateX : 0,
+                s.Hex != null ? s.Hex.CoordinateY : 0,
+                s.Population ?? 0))
+            .ToListAsync(ct);
+    }
+
+    public async Task<TownDto?> GetAsync(Guid settlementId, CancellationToken ct = default)
+    {
+        var settlement = await dbContext.Settlements
+            .AsNoTracking()
+            .Include(s => s.Hex)
+            .SingleOrDefaultAsync(s => s.SettlementId == settlementId, ct);
+
+        if (settlement is null)
+            return null;
+
+        return new TownDto(
+            settlement.SettlementId,
+            settlement.Name,
+            settlement.Hex?.CoordinateX ?? 0,
+            settlement.Hex?.CoordinateY ?? 0,
+            settlement.Population ?? 0);
+    }
+
+    public async Task<TownDto> CreateAsync(Guid kingdomId, CreateSettlementDto dto, CancellationToken ct = default)
+    {
+        var now = DateTime.UtcNow;
+
+        var settlement = new Settlement
+        {
+            SettlementId = Guid.NewGuid(),
+            KingdomId = kingdomId,
+            Name = dto.Name,
+            SettlementTypeId = dto.SettlementTypeId,
+            HexId = dto.HexId,
+            CreatedUtc = now,
+            ModifiedUtc = now
+        };
+
+        dbContext.Settlements.Add(settlement);
+        await dbContext.SaveChangesAsync(ct);
+
+        var result = await GetAsync(settlement.SettlementId, ct);
+        return result!;
+    }
+
+    public async Task<TownDto?> UpdateAsync(Guid settlementId, UpdateSettlementDto dto, CancellationToken ct = default)
+    {
+        var settlement = await dbContext.Settlements
+            .SingleOrDefaultAsync(s => s.SettlementId == settlementId, ct);
+
+        if (settlement is null)
+            return null;
+
+        settlement.Name = dto.Name;
+        settlement.SettlementTypeId = dto.SettlementTypeId;
+        settlement.HexId = dto.HexId;
+        settlement.Population = dto.Population;
+        settlement.Notes = dto.Notes;
+        settlement.ModifiedUtc = DateTime.UtcNow;
+
+        await dbContext.SaveChangesAsync(ct);
+
+        return await GetAsync(settlementId, ct);
+    }
+
+    public async Task<bool> DeleteAsync(Guid settlementId, CancellationToken ct = default)
+    {
+        var settlement = await dbContext.Settlements
+            .SingleOrDefaultAsync(s => s.SettlementId == settlementId, ct);
+
+        if (settlement is null)
+            return false;
+
+        dbContext.Settlements.Remove(settlement);
+        await dbContext.SaveChangesAsync(ct);
+
+        return true;
+    }
+}

--- a/dotnet10/KingmakerKingdomSheet.Application.Tests/KingdomManagementServiceTests.cs
+++ b/dotnet10/KingmakerKingdomSheet.Application.Tests/KingdomManagementServiceTests.cs
@@ -1,0 +1,163 @@
+using KingmakerKingdomSheet.ApiService.Data;
+using KingmakerKingdomSheet.ApiService.Services;
+using KingmakerKingdomSheet.Application.Contracts;
+using KingmakerKingdomSheet.Shared.DTOs;
+using Microsoft.EntityFrameworkCore;
+
+namespace KingmakerKingdomSheet.Application.Tests;
+
+public sealed class KingdomManagementServiceTests
+{
+    private static async Task<KingmakerDbContext> CreateInMemoryContextAsync()
+    {
+        var options = new DbContextOptionsBuilder<KingmakerDbContext>()
+            .UseSqlite("DataSource=:memory:")
+            .Options;
+
+        var context = new KingmakerDbContext(options);
+        context.Database.OpenConnection();
+        context.Database.EnsureCreated();
+
+        var gameMasterRole = new KingdomRoleType
+        {
+            KingdomRoleTypeId = 1,
+            Name = "game-master",
+            DisplayName = "Game Master",
+            IsGameMasterRole = true,
+            SortOrder = 10
+        };
+        context.KingdomRoleTypes.Add(gameMasterRole);
+
+        var user = new UserAccount
+        {
+            UserAccountId = Guid.NewGuid(),
+            DisplayName = "Test User",
+            Email = "test@example.com",
+            NormalizedEmail = "TEST@EXAMPLE.COM",
+            IdentityProvider = "local",
+            ExternalSubject = "local:test@example.com",
+            IsActive = true,
+            CreatedUtc = DateTime.UtcNow,
+            ModifiedUtc = DateTime.UtcNow
+        };
+        context.UserAccounts.Add(user);
+
+        await context.SaveChangesAsync();
+
+        return context;
+    }
+
+    [Fact]
+    public async Task CreateAsync_CreatesKingdomWithGameMasterRole()
+    {
+        await using var context = await CreateInMemoryContextAsync();
+        var catalogService = new SqliteKingdomCatalogService(context);
+        var managementService = new SqliteKingdomManagementService(context, catalogService);
+
+        var user = await context.UserAccounts.FirstAsync();
+        var dto = new CreateKingdomDto("Test Kingdom", "A test kingdom");
+
+        var result = await managementService.CreateAsync(user.UserAccountId, dto);
+
+        Assert.NotNull(result);
+        Assert.Equal("Test Kingdom", result.Name);
+        Assert.Equal(user.UserAccountId.ToString("D"), result.Members.Single().UserId);
+        Assert.Equal("Game Master", result.Members.Single().Role);
+
+        var kingdom = await context.Kingdoms
+            .Include(k => k.Participants)
+                .ThenInclude(p => p.Roles)
+            .FirstOrDefaultAsync(k => k.KingdomId == result.Id);
+
+        Assert.NotNull(kingdom);
+        Assert.Equal("test-kingdom", kingdom.Slug);
+        Assert.False(kingdom.IsArchived);
+        Assert.Single(kingdom.Participants);
+        Assert.Single(kingdom.Participants.First().Roles);
+    }
+
+    [Fact]
+    public async Task CreateAsync_GeneratesValidSlug()
+    {
+        await using var context = await CreateInMemoryContextAsync();
+        var catalogService = new SqliteKingdomCatalogService(context);
+        var managementService = new SqliteKingdomManagementService(context, catalogService);
+
+        var user = await context.UserAccounts.FirstAsync();
+        var dto = new CreateKingdomDto("My Test Kingdom! @#$", null);
+
+        var result = await managementService.CreateAsync(user.UserAccountId, dto);
+
+        var kingdom = await context.Kingdoms.FirstAsync(k => k.KingdomId == result.Id);
+        Assert.Equal("my-test-kingdom", kingdom.Slug);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ModifiesKingdomAndSlug()
+    {
+        await using var context = await CreateInMemoryContextAsync();
+        var catalogService = new SqliteKingdomCatalogService(context);
+        var managementService = new SqliteKingdomManagementService(context, catalogService);
+
+        var user = await context.UserAccounts.FirstAsync();
+        var createDto = new CreateKingdomDto("Original Name", "Original description");
+        var created = await managementService.CreateAsync(user.UserAccountId, createDto);
+
+        var updateDto = new UpdateKingdomDto("Updated Name", "Updated description");
+        var updated = await managementService.UpdateAsync(created.Id, updateDto);
+
+        Assert.NotNull(updated);
+        Assert.Equal("Updated Name", updated.Name);
+
+        var kingdom = await context.Kingdoms.FirstAsync(k => k.KingdomId == created.Id);
+        Assert.Equal("updated-name", kingdom.Slug);
+        Assert.Equal("Updated description", kingdom.Description);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ReturnsNullForNonexistentKingdom()
+    {
+        await using var context = await CreateInMemoryContextAsync();
+        var catalogService = new SqliteKingdomCatalogService(context);
+        var managementService = new SqliteKingdomManagementService(context, catalogService);
+
+        var updateDto = new UpdateKingdomDto("Test", null);
+        var result = await managementService.UpdateAsync(Guid.NewGuid(), updateDto);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ArchiveAsync_SoftDeletesKingdom()
+    {
+        await using var context = await CreateInMemoryContextAsync();
+        var catalogService = new SqliteKingdomCatalogService(context);
+        var managementService = new SqliteKingdomManagementService(context, catalogService);
+
+        var user = await context.UserAccounts.FirstAsync();
+        var createDto = new CreateKingdomDto("Test Kingdom", null);
+        var created = await managementService.CreateAsync(user.UserAccountId, createDto);
+
+        var success = await managementService.ArchiveAsync(created.Id);
+
+        Assert.True(success);
+
+        var kingdom = await context.Kingdoms.FirstAsync(k => k.KingdomId == created.Id);
+        Assert.True(kingdom.IsArchived);
+
+        var catalogResult = await catalogService.GetAsync(created.Id);
+        Assert.Null(catalogResult);
+    }
+
+    [Fact]
+    public async Task ArchiveAsync_ReturnsFalseForNonexistentKingdom()
+    {
+        await using var context = await CreateInMemoryContextAsync();
+        var catalogService = new SqliteKingdomCatalogService(context);
+        var managementService = new SqliteKingdomManagementService(context, catalogService);
+
+        var result = await managementService.ArchiveAsync(Guid.NewGuid());
+
+        Assert.False(result);
+    }
+}

--- a/dotnet10/KingmakerKingdomSheet.Application.Tests/SettlementServiceTests.cs
+++ b/dotnet10/KingmakerKingdomSheet.Application.Tests/SettlementServiceTests.cs
@@ -1,0 +1,242 @@
+using KingmakerKingdomSheet.ApiService.Data;
+using KingmakerKingdomSheet.ApiService.Services;
+using KingmakerKingdomSheet.Shared.DTOs;
+using Microsoft.EntityFrameworkCore;
+
+namespace KingmakerKingdomSheet.Application.Tests;
+
+public sealed class SettlementServiceTests
+{
+    private static async Task<KingmakerDbContext> CreateInMemoryContextAsync()
+    {
+        var options = new DbContextOptionsBuilder<KingmakerDbContext>()
+            .UseSqlite("DataSource=:memory:")
+            .Options;
+
+        var context = new KingmakerDbContext(options);
+        context.Database.OpenConnection();
+        context.Database.EnsureCreated();
+
+        var settlementType = new SettlementType
+        {
+            SettlementTypeId = 1,
+            Name = "town",
+            DisplayName = "Town",
+            MinDistricts = 1,
+            SortOrder = 10
+        };
+        context.SettlementTypes.Add(settlementType);
+
+        var kingdom = new Kingdom
+        {
+            KingdomId = Guid.NewGuid(),
+            Name = "Test Kingdom",
+            Slug = "test-kingdom",
+            IsArchived = false,
+            CreatedUtc = DateTime.UtcNow,
+            ModifiedUtc = DateTime.UtcNow
+        };
+        context.Kingdoms.Add(kingdom);
+
+        var terrainType = new HexTerrainType
+        {
+            HexTerrainTypeId = 1,
+            Name = "plains",
+            DisplayName = "Plains",
+            MovementCost = 1.0m,
+            IsWater = false,
+            SupportsSettlement = true,
+            SortOrder = 10
+        };
+        context.HexTerrainTypes.Add(terrainType);
+
+        var claimStatus = new ClaimStatus
+        {
+            ClaimStatusId = 1,
+            Name = "claimed",
+            DisplayName = "Claimed",
+            IsClaimed = true,
+            SortOrder = 10
+        };
+        context.ClaimStatuses.Add(claimStatus);
+
+        var fogState = new FogState
+        {
+            FogStateId = 1,
+            Name = "explored",
+            DisplayName = "Explored",
+            SortOrder = 10
+        };
+        context.FogStates.Add(fogState);
+
+        var hex = new Hex
+        {
+            HexId = Guid.NewGuid(),
+            KingdomId = kingdom.KingdomId,
+            CoordinateX = 10,
+            CoordinateY = 20,
+            HexTerrainTypeId = 1,
+            ClaimStatusId = 1,
+            FogStateId = 1,
+            CreatedUtc = DateTime.UtcNow,
+            ModifiedUtc = DateTime.UtcNow
+        };
+        context.Hexes.Add(hex);
+
+        await context.SaveChangesAsync();
+
+        return context;
+    }
+
+    [Fact]
+    public async Task CreateAsync_CreatesSettlement()
+    {
+        await using var context = await CreateInMemoryContextAsync();
+        var settlementService = new SqliteSettlementService(context);
+
+        var kingdom = await context.Kingdoms.FirstAsync();
+        var hex = await context.Hexes.FirstAsync();
+        var dto = new CreateSettlementDto("New Town", 1, hex.HexId);
+
+        var result = await settlementService.CreateAsync(kingdom.KingdomId, dto);
+
+        Assert.NotNull(result);
+        Assert.Equal("New Town", result.Name);
+        Assert.Equal(10, result.Column);
+        Assert.Equal(20, result.Row);
+
+        var settlement = await context.Settlements.FirstOrDefaultAsync(s => s.SettlementId == result.Id);
+        Assert.NotNull(settlement);
+        Assert.Equal(kingdom.KingdomId, settlement.KingdomId);
+        Assert.Equal(hex.HexId, settlement.HexId);
+    }
+
+    [Fact]
+    public async Task CreateAsync_CreatesSettlementWithoutHex()
+    {
+        await using var context = await CreateInMemoryContextAsync();
+        var settlementService = new SqliteSettlementService(context);
+
+        var kingdom = await context.Kingdoms.FirstAsync();
+        var dto = new CreateSettlementDto("Floating Town", 1, null);
+
+        var result = await settlementService.CreateAsync(kingdom.KingdomId, dto);
+
+        Assert.NotNull(result);
+        Assert.Equal("Floating Town", result.Name);
+        Assert.Equal(0, result.Column);
+        Assert.Equal(0, result.Row);
+
+        var settlement = await context.Settlements.FirstOrDefaultAsync(s => s.SettlementId == result.Id);
+        Assert.NotNull(settlement);
+        Assert.Null(settlement.HexId);
+    }
+
+    [Fact]
+    public async Task ListByKingdomAsync_ReturnsAllSettlements()
+    {
+        await using var context = await CreateInMemoryContextAsync();
+        var settlementService = new SqliteSettlementService(context);
+
+        var kingdom = await context.Kingdoms.FirstAsync();
+        var hex = await context.Hexes.FirstAsync();
+
+        await settlementService.CreateAsync(kingdom.KingdomId, new CreateSettlementDto("Town A", 1, hex.HexId));
+        await settlementService.CreateAsync(kingdom.KingdomId, new CreateSettlementDto("Town B", 1, null));
+
+        var result = await settlementService.ListByKingdomAsync(kingdom.KingdomId);
+
+        Assert.Equal(2, result.Count);
+        Assert.Contains(result, s => s.Name == "Town A");
+        Assert.Contains(result, s => s.Name == "Town B");
+    }
+
+    [Fact]
+    public async Task GetAsync_ReturnsSettlement()
+    {
+        await using var context = await CreateInMemoryContextAsync();
+        var settlementService = new SqliteSettlementService(context);
+
+        var kingdom = await context.Kingdoms.FirstAsync();
+        var created = await settlementService.CreateAsync(kingdom.KingdomId, new CreateSettlementDto("Test Town", 1, null));
+
+        var result = await settlementService.GetAsync(created.Id);
+
+        Assert.NotNull(result);
+        Assert.Equal("Test Town", result.Name);
+    }
+
+    [Fact]
+    public async Task GetAsync_ReturnsNullForNonexistent()
+    {
+        await using var context = await CreateInMemoryContextAsync();
+        var settlementService = new SqliteSettlementService(context);
+
+        var result = await settlementService.GetAsync(Guid.NewGuid());
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ModifiesSettlement()
+    {
+        await using var context = await CreateInMemoryContextAsync();
+        var settlementService = new SqliteSettlementService(context);
+
+        var kingdom = await context.Kingdoms.FirstAsync();
+        var hex = await context.Hexes.FirstAsync();
+        var created = await settlementService.CreateAsync(kingdom.KingdomId, new CreateSettlementDto("Original", 1, null));
+
+        var updateDto = new UpdateSettlementDto("Updated Town", 1, hex.HexId, 5000, "Test notes");
+        var updated = await settlementService.UpdateAsync(created.Id, updateDto);
+
+        Assert.NotNull(updated);
+        Assert.Equal("Updated Town", updated.Name);
+        Assert.Equal(5000, updated.Population);
+        Assert.Equal(10, updated.Column);
+        Assert.Equal(20, updated.Row);
+
+        var settlement = await context.Settlements.FirstAsync(s => s.SettlementId == created.Id);
+        Assert.Equal("Test notes", settlement.Notes);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ReturnsNullForNonexistent()
+    {
+        await using var context = await CreateInMemoryContextAsync();
+        var settlementService = new SqliteSettlementService(context);
+
+        var updateDto = new UpdateSettlementDto("Test", 1, null, null, null);
+        var result = await settlementService.UpdateAsync(Guid.NewGuid(), updateDto);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_RemovesSettlement()
+    {
+        await using var context = await CreateInMemoryContextAsync();
+        var settlementService = new SqliteSettlementService(context);
+
+        var kingdom = await context.Kingdoms.FirstAsync();
+        var created = await settlementService.CreateAsync(kingdom.KingdomId, new CreateSettlementDto("To Delete", 1, null));
+
+        var success = await settlementService.DeleteAsync(created.Id);
+
+        Assert.True(success);
+
+        var settlement = await context.Settlements.FirstOrDefaultAsync(s => s.SettlementId == created.Id);
+        Assert.Null(settlement);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ReturnsFalseForNonexistent()
+    {
+        await using var context = await CreateInMemoryContextAsync();
+        var settlementService = new SqliteSettlementService(context);
+
+        var result = await settlementService.DeleteAsync(Guid.NewGuid());
+
+        Assert.False(result);
+    }
+}

--- a/dotnet10/KingmakerKingdomSheet.Application/Contracts/IKingdomManagementService.cs
+++ b/dotnet10/KingmakerKingdomSheet.Application/Contracts/IKingdomManagementService.cs
@@ -1,0 +1,10 @@
+using KingmakerKingdomSheet.Shared.DTOs;
+
+namespace KingmakerKingdomSheet.Application.Contracts;
+
+public interface IKingdomManagementService
+{
+    Task<KingdomDetailsDto> CreateAsync(Guid createdByUserId, CreateKingdomDto dto, CancellationToken ct = default);
+    Task<KingdomDetailsDto?> UpdateAsync(Guid kingdomId, UpdateKingdomDto dto, CancellationToken ct = default);
+    Task<bool> ArchiveAsync(Guid kingdomId, CancellationToken ct = default);
+}

--- a/dotnet10/KingmakerKingdomSheet.Application/Contracts/ISettlementService.cs
+++ b/dotnet10/KingmakerKingdomSheet.Application/Contracts/ISettlementService.cs
@@ -1,0 +1,12 @@
+using KingmakerKingdomSheet.Shared.DTOs;
+
+namespace KingmakerKingdomSheet.Application.Contracts;
+
+public interface ISettlementService
+{
+    Task<IReadOnlyList<TownDto>> ListByKingdomAsync(Guid kingdomId, CancellationToken ct = default);
+    Task<TownDto?> GetAsync(Guid settlementId, CancellationToken ct = default);
+    Task<TownDto> CreateAsync(Guid kingdomId, CreateSettlementDto dto, CancellationToken ct = default);
+    Task<TownDto?> UpdateAsync(Guid settlementId, UpdateSettlementDto dto, CancellationToken ct = default);
+    Task<bool> DeleteAsync(Guid settlementId, CancellationToken ct = default);
+}

--- a/dotnet10/KingmakerKingdomSheet.Shared/DTOs/CreateKingdomDto.cs
+++ b/dotnet10/KingmakerKingdomSheet.Shared/DTOs/CreateKingdomDto.cs
@@ -1,0 +1,3 @@
+namespace KingmakerKingdomSheet.Shared.DTOs;
+
+public sealed record CreateKingdomDto(string Name, string? Description);

--- a/dotnet10/KingmakerKingdomSheet.Shared/DTOs/CreateSettlementDto.cs
+++ b/dotnet10/KingmakerKingdomSheet.Shared/DTOs/CreateSettlementDto.cs
@@ -1,0 +1,3 @@
+namespace KingmakerKingdomSheet.Shared.DTOs;
+
+public sealed record CreateSettlementDto(string Name, byte SettlementTypeId, Guid? HexId);

--- a/dotnet10/KingmakerKingdomSheet.Shared/DTOs/UpdateKingdomDto.cs
+++ b/dotnet10/KingmakerKingdomSheet.Shared/DTOs/UpdateKingdomDto.cs
@@ -1,0 +1,3 @@
+namespace KingmakerKingdomSheet.Shared.DTOs;
+
+public sealed record UpdateKingdomDto(string Name, string? Description);

--- a/dotnet10/KingmakerKingdomSheet.Shared/DTOs/UpdateSettlementDto.cs
+++ b/dotnet10/KingmakerKingdomSheet.Shared/DTOs/UpdateSettlementDto.cs
@@ -1,0 +1,3 @@
+namespace KingmakerKingdomSheet.Shared.DTOs;
+
+public sealed record UpdateSettlementDto(string Name, byte SettlementTypeId, Guid? HexId, int? Population, string? Notes);


### PR DESCRIPTION
## Summary

Implements issue #6: REST endpoints for CRUD operations on kingdoms and settlements.

### API Endpoints

**Kingdoms** (\/api/kingdoms\)
| Method | Route | Auth | Permission |
|--------|-------|------|-----------|
| GET | \/api/kingdoms\ | Public | — |
| GET | \/api/kingdoms/{id}\ | Public | — |
| POST | \/api/kingdoms\ | Auth | — |
| PUT | \/api/kingdoms/{id}\ | Auth | \manage-kingdom\ |
| DELETE | \/api/kingdoms/{id}\ | Auth | \manage-kingdom\ |

**Settlements** (\/api/kingdoms/{kingdomId}/settlements\)
| Method | Route | Auth | Permission |
|--------|-------|------|-----------|
| GET | \/\ | Public | — |
| GET | \/{id}\ | Public | — |
| POST | \/\ | Auth | \manage-settlements\ |
| PUT | \/{id}\ | Auth | \manage-settlements\ |
| DELETE | \/{id}\ | Auth | \manage-settlements\ |

### Services
- \IKingdomManagementService\ — Create/Update/Archive kingdoms with auto-slug generation, auto Game Master role assignment
- \ISettlementService\ — Full CRUD for settlements scoped to kingdoms

### Cleanup
- Removed deprecated \/weatherforecast\ endpoint

### Tests
33 tests passing (15 new kingdom/settlement service tests + 16 auth tests + 2 domain tests)

Closes #6